### PR TITLE
Migrate older classes to Dataset function

### DIFF
--- a/importer/AtDe.py
+++ b/importer/AtDe.py
@@ -1,5 +1,6 @@
-from Monument import Monument
+from Monument import Monument, Dataset
 import importer_utils as utils
+import importer as importer
 
 
 MAPPING_DIR = "mappings"
@@ -138,8 +139,8 @@ class AtDe(Monument):
             if len(match) == 1:
                 self.add_statement("located_adm", match[0])
             else:
-                self.add_to_report("gemeindekennzahl",
-                    municip_code, "located_adm")     
+                self.add_to_report(
+                    "gemeindekennzahl", municip_code, "located_adm")
 
     def exists_with_monument_article(self, language):
         return super().exists_with_monument_article("de", "artikel")
@@ -163,3 +164,12 @@ class AtDe(Monument):
         self.set_coords(("lat", "lon"))
         self.set_commonscat()
         self.set_wd_item(self.find_matching_wikidata(mapping))
+
+
+if __name__ == "__main__":
+    """Point of entrance for importer."""
+    args = importer.handle_args()
+    dataset = Dataset("at", "de", AtDe)
+    dataset.data_files = {"municipalities": "austria_municipalities.json"}
+    dataset.lookup_downloads = {"types": "at_(de)/types"}
+    importer.main(args, dataset)

--- a/importer/CzCs.py
+++ b/importer/CzCs.py
@@ -1,5 +1,6 @@
-from Monument import Monument
+from Monument import Monument, Dataset
 import importer_utils as utils
+import importer as importer
 
 
 class CzCs(Monument):
@@ -33,3 +34,10 @@ class CzCs(Monument):
         # self.set_location()
         self.exists_with_prop(mapping)
         # self.print_wd()
+
+
+if __name__ == "__main__":
+    """Point of entrance for importer."""
+    args = importer.handle_args()
+    dataset = Dataset("cz", "cs", CzCs)
+    importer.main(args, dataset)

--- a/importer/DkBygningDa.py
+++ b/importer/DkBygningDa.py
@@ -1,5 +1,6 @@
-from Monument import Monument
+from Monument import Monument, Dataset
 import importer_utils as utils
+import importer as importer
 
 
 class DkBygningDa(Monument):
@@ -83,3 +84,11 @@ class DkBygningDa(Monument):
         self.set_inception()
         self.exists_with_prop(mapping)
         self.print_wd()
+
+
+if __name__ == "__main__":
+    """Point of entrance for importer."""
+    args = importer.handle_args()
+    dataset = Dataset("dk-bygninger", "da", DkBygningDa)
+    dataset.subclass_downloads = {"settlement": "Q486972"}
+    importer.main(args, dataset)

--- a/importer/DkFortidsDa.py
+++ b/importer/DkFortidsDa.py
@@ -1,5 +1,6 @@
-from Monument import Monument
+from Monument import Monument, Dataset
 import importer_utils as utils
+import importer as importer
 
 
 class DkFortidsDa(Monument):
@@ -76,7 +77,6 @@ class DkFortidsDa(Monument):
                                 for x in table
                                 if x == self.type]
                 special_type = special_type[0][0]
-                ref = self.wlm_source
                 self.substitute_statement("is", special_type)
             except IndexError:
                 self.add_to_report("type", self.type)
@@ -113,3 +113,13 @@ class DkFortidsDa(Monument):
         self.set_type()
         self.set_id()
         self.set_wd_item(self.find_matching_wikidata(mapping))
+
+
+if __name__ == "__main__":
+    """Point of entrance for importer."""
+    args = importer.handle_args()
+    dataset = Dataset("dk-fortidsminder", "da", DkFortidsDa)
+    dataset.data_files = {
+        "types": "dk-fortidsminder_(da)_types.json",
+        "municipalities": "denmark_municipalities.json"}
+    importer.main(args, dataset)

--- a/importer/EeEt.py
+++ b/importer/EeEt.py
@@ -139,7 +139,8 @@ if __name__ == "__main__":
     dataset = Dataset("ee", "et", EeEt)
     dataset.data_files = {
         "municipalities": "estonia_municipalities.json",
-        "settlements": "estonia_settlements.json"
+        "settlements": "estonia_settlements.json",
+        "counties": "estonia_counties.json"
     }
     dataset.lookup_downloads = {
         "heritage_types": "ee (et)/types"

--- a/importer/HuHu.py
+++ b/importer/HuHu.py
@@ -1,5 +1,6 @@
-from Monument import Monument
+from Monument import Monument, Dataset
 import importer_utils as utils
+import importer as importer
 
 class HuHu(Monument):
 
@@ -22,3 +23,10 @@ class HuHu(Monument):
         # self.set_location()
         self.exists_with_prop(mapping)
         self.print_wd()
+
+
+if __name__ == "__main__":
+    """Point of entrance for importer."""
+    args = importer.handle_args()
+    dataset = Dataset("hu", "hu", HuHu)
+    importer.main(args, dataset)

--- a/importer/IeEn.py
+++ b/importer/IeEn.py
@@ -1,4 +1,4 @@
-from Monument import Monument
+from Monument import Monument, Dataset
 import importer_utils as utils
 
 
@@ -31,3 +31,13 @@ class IeEn(Monument):
         # self.set_location()
         # self.exists_with_prop(mapping)
         self.print_wd()
+
+
+if __name__ == "__main__":
+    """Command line entry point for importer."""
+    args = importer.handle_args()
+    dataset = Dataset("ie", "en", IeEn)
+    dataset.data_files = {
+        "counties": "ireland_counties.json"
+    }
+    importer.main(args, dataset)

--- a/importer/IeEn.py
+++ b/importer/IeEn.py
@@ -1,5 +1,6 @@
 from Monument import Monument, Dataset
 import importer_utils as utils
+import importer as importer
 
 
 class IeEn(Monument):

--- a/importer/NoNo.py
+++ b/importer/NoNo.py
@@ -1,4 +1,4 @@
-from Monument import Monument
+from Monument import Monument, Dataset
 import importer_utils as utils
 
 
@@ -51,3 +51,10 @@ class NoNo(Monument):
         # self.set_inception()
         self.exists_with_prop(mapping)
         self.print_wd()
+
+
+if __name__ == "__main__":
+    """Command line entry point for importer."""
+    args = importer.handle_args()
+    dataset = Dataset("no", "no", NoNo)
+    importer.main(args, dataset)

--- a/importer/NoNo.py
+++ b/importer/NoNo.py
@@ -1,5 +1,6 @@
 from Monument import Monument, Dataset
 import importer_utils as utils
+import importer as importer
 
 
 class NoNo(Monument):

--- a/importer/PlPl.py
+++ b/importer/PlPl.py
@@ -1,4 +1,4 @@
-from Monument import Monument
+from Monument import Monument, Dataset
 import importer_utils as utils
 
 
@@ -80,3 +80,13 @@ class PlPl(Monument):
         self.set_location()
         self.set_address()
         self.exists_with_prop(mapping)
+
+
+if __name__ == "__main__":
+    """Command line entry point for importer."""
+    args = importer.handle_args()
+    dataset = Dataset("pl", "pl", PlPl)
+    dataset.data_files = {
+        "settlements": "poland_settlements.json"
+    }
+    importer.main(args, dataset)

--- a/importer/PlPl.py
+++ b/importer/PlPl.py
@@ -1,5 +1,6 @@
 from Monument import Monument, Dataset
 import importer_utils as utils
+import importer as importer
 
 
 class PlPl(Monument):

--- a/importer/PtPt.py
+++ b/importer/PtPt.py
@@ -1,5 +1,6 @@
-from Monument import Monument
+from Monument import Monument, Dataset
 import importer_utils as utils
+import importer as importer
 
 
 class PtPt(Monument):
@@ -37,3 +38,10 @@ class PtPt(Monument):
         # self.set_location()
         self.exists_with_prop(mapping)
         # self.print_wd()
+
+
+if __name__ == "__main__":
+    """Point of entrance for importer."""
+    args = importer.handle_args()
+    dataset = Dataset("pt", "pt", PtPt)
+    importer.main(args, dataset)

--- a/importer/SeArbetslSv.py
+++ b/importer/SeArbetslSv.py
@@ -1,5 +1,6 @@
-from Monument import Monument
+from Monument import Monument, Dataset
 import importer_utils as utils
+import importer as importer
 
 
 class SeArbetslSv(Monument):
@@ -154,3 +155,14 @@ class SeArbetslSv(Monument):
         self.set_coords(("lat", "lon"))
         self.set_wd_item(self.find_matching_wikidata(mapping))
         # self.print_wd()
+
+
+if __name__ == "__main__":
+    """Point of entrance for importer."""
+    args = importer.handle_args()
+    dataset = Dataset("se-arbetsl", "sv", SeArbetslSv)
+    dataset.data_files = {
+        "municipalities": "sweden_municipalities.json",
+        "types": "se-arbetsl_(sv)_types.json",
+        "settlements": "sweden_settlements.json"}
+    importer.main(args, dataset)

--- a/importer/SeBbrSv.py
+++ b/importer/SeBbrSv.py
@@ -1,5 +1,6 @@
-from Monument import Monument
+from Monument import Monument, Dataset
 import importer_utils as utils
+import importer as importer
 import requests
 from os import path
 
@@ -407,3 +408,13 @@ class SeBbrSv(Monument):
         self.set_function()
         self.set_wd_item(self.find_matching_wikidata(mapping))
         self.check_wd_item()
+
+
+if __name__ == "__main__":
+    """Point of entrance for importer."""
+    args = importer.handle_args()
+    dataset = Dataset("se-bbr", "sv", SeBbrSv)
+    dataset.data_files = {
+        "functions": "se-bbr_(sv)_functions.json",
+        "settlements": "sweden_settlements.json"}
+    importer.main(args, dataset)

--- a/importer/SeShipSv.py
+++ b/importer/SeShipSv.py
@@ -1,5 +1,6 @@
-from Monument import Monument
+from Monument import Monument, Dataset
 import importer_utils as utils
+import importer as importer
 
 
 class SeShipSv(Monument):
@@ -163,3 +164,12 @@ class SeShipSv(Monument):
         self.set_homeport()
         self.set_dimensions()
         self.exists_with_prop(mapping)
+
+
+if __name__ == "__main__":
+    """Command line entry point for importer."""
+    args = importer.handle_args()
+    dataset = Dataset("se-ship", "sv", SeShipSv)
+    dataset.data_files = {
+        "functions": "se-ship_(sv)_functions.json"}
+    importer.main(args, dataset)

--- a/importer/ZaEn.py
+++ b/importer/ZaEn.py
@@ -1,5 +1,6 @@
 from Monument import Monument, Dataset
 import importer_utils as utils
+import importer as importer
 
 
 class ZaEn(Monument):

--- a/importer/ZaEn.py
+++ b/importer/ZaEn.py
@@ -1,4 +1,4 @@
-from Monument import Monument
+from Monument import Monument, Dataset
 import importer_utils as utils
 
 
@@ -24,3 +24,10 @@ class ZaEn(Monument):
         # self.set_location()
         self.exists_with_prop(mapping)
         # self.print_wd()
+
+
+if __name__ == "__main__":
+    """Command line entry point for importer."""
+    args = importer.handle_args()
+    dataset = Dataset("za", "en", ZaEn)
+    importer.main(args, dataset)

--- a/importer/importer.py
+++ b/importer/importer.py
@@ -338,8 +338,6 @@ def make_dataset(country, language):
     Only kept for backwards-compatibility with older monument classes.
     """
     from Monument import Dataset
-    from DkBygningDa import DkBygningDa
-    from DkFortidsDa import DkFortidsDa
     from EeEt import EeEt
     from IeEn import IeEn
     from NoNo import NoNo
@@ -350,18 +348,9 @@ def make_dataset(country, language):
             "class": IeEn,
             "data_files": {"counties": "ireland_counties.json"}},
         "monuments_za_(en)": {"class": ZaEn, "data_files": {}},
-        "monuments_dk-bygninger_(da)": {
-            "class": DkBygningDa,
-            "data_files": {},
-            "subclass_downloads": {"settlement": "Q486972"}},
         "monuments_pl_(pl)": {
             "class": PlPl,
             "data_files": {"settlements": "poland_settlements.json"}},
-        "monuments_dk-fortidsminder_(da)": {
-            "class": DkFortidsDa,
-            "data_files": {
-                "types": "dk-fortidsminder_(da)_types.json",
-                "municipalities": "denmark_municipalities.json"}},
         "monuments_no_(no)": {"class": NoNo, "data_files": {}},
         "monuments_ee_(et)": {
             "class": EeEt,

--- a/importer/importer.py
+++ b/importer/importer.py
@@ -310,8 +310,8 @@ def format_matched_p31s_rows(matched_item_p31s):
     return rows
 
 
-def main(arguments, dataset=None):
-    """Process the arguments and fetch data according to them"""
+def main(arguments, dataset):
+    """Process the arguments and fetch data for the provided dataset."""
     arguments = vars(arguments)
     if on_forge():
         arguments["host"] = "tools-db"
@@ -326,33 +326,7 @@ def main(arguments, dataset=None):
     table = arguments["table"]
     list_matches = arguments["list_matches"]
 
-    dataset = dataset or make_dataset(
-        arguments["country"], arguments["language"])
     get_items(connection, dataset, upload, short, offset, table, list_matches)
-
-
-def make_dataset(country, language):
-    """
-    Construct a dataset instance for the provided country and language codes.
-
-    Only kept for backwards-compatibility with older monument classes.
-    """
-    from Monument import Dataset
-    SPECIFIC_TABLES = {}
-    specific_table_name = utils.get_specific_table_name(country, language)
-    specific_table = None
-    if specific_table_name in SPECIFIC_TABLES:
-        specific_table = SPECIFIC_TABLES[specific_table_name]
-    else:
-        print("No class defined for {0}.".format(specific_table_name))
-        exit()
-
-    dataset = Dataset(country, language, specific_table["class"])
-    dataset.data_files = specific_table.get("data_files")
-    dataset.lookup_downloads = specific_table.get("lookup_downloads")
-    dataset.subclass_downloads = specific_table.get("subclass_downloads")
-
-    return dataset
 
 
 def get_db_credentials():
@@ -386,8 +360,6 @@ def handle_args(*args):
         --db Name of the database to connect to.
         --user Username to connect to the database.
         --password Password to connect to the database.
-        --language Language code of the table to fetch, eg. "sv".
-        --country Country of the table to fetch, eg. "se-fornmin".
         --upload Whether to upload the processed items. Two options:
             --upload sandbox Upload to the Wikidata sandbox item.
             --upload live Live upload to real Wikidata items.
@@ -401,8 +373,6 @@ def handle_args(*args):
         parser.add_argument("--db", default="wlm")
         parser.add_argument("--user", default="root")
         parser.add_argument("--password", default="")
-    parser.add_argument("--language", default="sv")
-    parser.add_argument("--country", default="se-ship")
     parser.add_argument("--upload", action='store')
     parser.add_argument("--short",
                         const=DEFAULT_SHORT,

--- a/importer/importer.py
+++ b/importer/importer.py
@@ -338,28 +338,15 @@ def make_dataset(country, language):
     Only kept for backwards-compatibility with older monument classes.
     """
     from Monument import Dataset
-    from CzCs import CzCs
     from AtDe import AtDe
     from DkBygningDa import DkBygningDa
     from DkFortidsDa import DkFortidsDa
     from EeEt import EeEt
-    from HuHu import HuHu
     from IeEn import IeEn
     from NoNo import NoNo
     from PlPl import PlPl
-    from PtPt import PtPt
-    from SeArbetslSv import SeArbetslSv
-    from SeBbrSv import SeBbrSv
-    from SeShipSv import SeShipSv
     from ZaEn import ZaEn
     SPECIFIC_TABLES = {
-        "monuments_se-ship_(sv)": {
-            "class": SeShipSv,
-            "data_files": {
-                "functions": "se-ship_(sv)_functions.json"}},
-        "monuments_cz_(cs)": {"class": CzCs, "data_files": {}},
-        "monuments_hu_(hu)": {"class": HuHu, "data_files": {}},
-        "monuments_pt_(pt)": {"class": PtPt, "data_files": {}},
         "monuments_ie_(en)": {
             "class": IeEn,
             "data_files": {"counties": "ireland_counties.json"}},
@@ -383,20 +370,9 @@ def make_dataset(country, language):
                 "types": "dk-fortidsminder_(da)_types.json",
                 "municipalities": "denmark_municipalities.json"}},
         "monuments_no_(no)": {"class": NoNo, "data_files": {}},
-        "monuments_se-bbr_(sv)": {
-            "class": SeBbrSv,
-            "data_files": {
-                "functions": "se-bbr_(sv)_functions.json",
-                "settlements": "sweden_settlements.json"}},
         "monuments_ee_(et)": {
             "class": EeEt,
-            "data_files": {"counties": "estonia_counties.json"}},
-        "monuments_se-arbetsl_(sv)": {
-            "class": SeArbetslSv,
-            "data_files": {
-                "municipalities": "sweden_municipalities.json",
-                "types": "se-arbetsl_(sv)_types.json",
-                "settlements": "sweden_settlements.json"}}
+            "data_files": {"counties": "estonia_counties.json"}}
         }
     specific_table_name = utils.get_specific_table_name(country, language)
     specific_table = None

--- a/importer/importer.py
+++ b/importer/importer.py
@@ -338,7 +338,6 @@ def make_dataset(country, language):
     Only kept for backwards-compatibility with older monument classes.
     """
     from Monument import Dataset
-    from AtDe import AtDe
     from DkBygningDa import DkBygningDa
     from DkFortidsDa import DkFortidsDa
     from EeEt import EeEt
@@ -351,12 +350,6 @@ def make_dataset(country, language):
             "class": IeEn,
             "data_files": {"counties": "ireland_counties.json"}},
         "monuments_za_(en)": {"class": ZaEn, "data_files": {}},
-        "monuments_at_(de)": {
-            "class": AtDe,
-            "data_files": {
-                "municipalities": "austria_municipalities.json"},
-            "lookup_downloads": {
-                "types": "at_(de)/types"}},
         "monuments_dk-bygninger_(da)": {
             "class": DkBygningDa,
             "data_files": {},

--- a/importer/importer.py
+++ b/importer/importer.py
@@ -338,24 +338,7 @@ def make_dataset(country, language):
     Only kept for backwards-compatibility with older monument classes.
     """
     from Monument import Dataset
-    from EeEt import EeEt
-    from IeEn import IeEn
-    from NoNo import NoNo
-    from PlPl import PlPl
-    from ZaEn import ZaEn
-    SPECIFIC_TABLES = {
-        "monuments_ie_(en)": {
-            "class": IeEn,
-            "data_files": {"counties": "ireland_counties.json"}},
-        "monuments_za_(en)": {"class": ZaEn, "data_files": {}},
-        "monuments_pl_(pl)": {
-            "class": PlPl,
-            "data_files": {"settlements": "poland_settlements.json"}},
-        "monuments_no_(no)": {"class": NoNo, "data_files": {}},
-        "monuments_ee_(et)": {
-            "class": EeEt,
-            "data_files": {"counties": "estonia_counties.json"}}
-        }
+    SPECIFIC_TABLES = {}
     specific_table_name = utils.get_specific_table_name(country, language)
     specific_table = None
     if specific_table_name in SPECIFIC_TABLES:


### PR DESCRIPTION
Migrate older classes to `Dataset` function and drop functionality (and arguments) needed for the old mechanism.

Task: [T173910](https://phabricator.wikimedia.org/T173910)